### PR TITLE
Feat+Refactor: Introduce "Replacement" Feature

### DIFF
--- a/src/ExpressionInterface.php
+++ b/src/ExpressionInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Mpyw\LaravelMySqlSystemVariableManager;
+
+interface ExpressionInterface
+{
+    public const TYPE_INTEGER = 'integer';
+    public const TYPE_BOOLEAN = 'boolean';
+    public const TYPE_FLOAT = 'double';
+    public const TYPE_STRING = 'string';
+
+    public const GRAMMATICAL_TYPE_TO_STRING_TYPE = [
+        'int' => self::TYPE_INTEGER,
+        'bool' => self::TYPE_BOOLEAN,
+        'float' => self::TYPE_FLOAT,
+        'double' => self::TYPE_FLOAT,
+        'string' => self::TYPE_STRING,
+    ];
+
+    /**
+     * Return type.
+     *
+     * @return string
+     */
+    public function getType(): string;
+
+    /**
+     * Return PDO::PARAM_* type.s
+     *
+     * @return int
+     */
+    public function getParamType(): int;
+
+    /**
+     * Return placeholder for prepared statement.
+     *
+     * @return string
+     */
+    public function getPlaceholder(): string;
+}

--- a/src/ExpressionTrait.php
+++ b/src/ExpressionTrait.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Mpyw\LaravelMySqlSystemVariableManager;
+
+use PDO;
+
+/**
+ * Trait ExpressionTrait
+ */
+trait ExpressionTrait
+{
+    /**
+     * Return type.
+     *
+     * @return string
+     */
+    abstract public function getType(): string;
+
+    /**
+     * Return PDO::PARAM_* type.
+     *
+     * @return int
+     */
+    public function getParamType(): int
+    {
+        switch ($this->getType()) {
+            case ExpressionInterface::TYPE_INTEGER:
+                return PDO::PARAM_INT;
+            case ExpressionInterface::TYPE_BOOLEAN:
+                return PDO::PARAM_BOOL;
+            case ExpressionInterface::TYPE_FLOAT:
+            case ExpressionInterface::TYPE_STRING:
+            default:
+                return PDO::PARAM_STR;
+        }
+    }
+
+    /**
+     * Return a placeholder format.
+     *
+     * @return string
+     */
+    public function getPlaceholder(): string
+    {
+        switch ($this->getType()) {
+            case ExpressionInterface::TYPE_FLOAT:
+                return 'cast(? as decimal(65, 30))';
+            case ExpressionInterface::TYPE_INTEGER:
+            case ExpressionInterface::TYPE_BOOLEAN:
+            case ExpressionInterface::TYPE_STRING:
+            default:
+                return '?';
+        }
+    }
+}

--- a/src/ManagesSystemVariables.php
+++ b/src/ManagesSystemVariables.php
@@ -52,4 +52,36 @@ trait ManagesSystemVariables
 
         return $this;
     }
+
+    /**
+     * Run callback temporarily setting MySQL system variable for both read and write PDOs.
+     * It is lazily executed for unresolved PDO instance.
+     *
+     * @param  string   $key
+     * @param  mixed    $value
+     * @param  callable $callback
+     * @param  mixed    ...$args
+     * @return $this
+     */
+    public function usingSystemVariable(string $key, $value, callable $callback, ...$args)
+    {
+        return $this->usingSystemVariables([$key => $value], $callback, ...$args);
+    }
+
+    /**
+     * Run callback temporarily setting MySQL system variables for both read and write PDOs.
+     * It is lazily executed for unresolved PDO instance.
+     *
+     * @param  array    $values
+     * @param  callable $callback
+     * @param  mixed    ...$args
+     * @return $this
+     */
+    public function usingSystemVariables(array $values, callable $callback, ...$args)
+    {
+        (new SystemVariableTemporaryAssigner($this->readPdo, $this->pdo))
+            ->using($values, $callback, ...$args);
+
+        return $this;
+    }
 }

--- a/src/Replacer.php
+++ b/src/Replacer.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Mpyw\LaravelMySqlSystemVariableManager;
+
+use InvalidArgumentException;
+use Mpyw\LaravelMySqlSystemVariableManager\Replacers\BooleanReplacerInterface;
+use Mpyw\LaravelMySqlSystemVariableManager\Replacers\CallbackBooleanReplacer;
+use Mpyw\LaravelMySqlSystemVariableManager\Replacers\CallbackFloatReplacer;
+use Mpyw\LaravelMySqlSystemVariableManager\Replacers\CallbackIntegerReplacer;
+use Mpyw\LaravelMySqlSystemVariableManager\Replacers\CallbackStringReplacer;
+use Mpyw\LaravelMySqlSystemVariableManager\Replacers\FloatReplacerInterface;
+use Mpyw\LaravelMySqlSystemVariableManager\Replacers\IntegerReplacerInterface;
+use Mpyw\LaravelMySqlSystemVariableManager\Replacers\StringReplacerInterface;
+
+class Replacer
+{
+    /**
+     * Create new int replacer for MySQL system variable.
+     *
+     * @param  callable                                                                   $callback
+     * @return \Mpyw\LaravelMySqlSystemVariableManager\Replacers\IntegerReplacerInterface
+     */
+    public static function int(callable $callback): IntegerReplacerInterface
+    {
+        return new CallbackIntegerReplacer($callback);
+    }
+
+    /**
+     * Create new bool replacer for MySQL system variable.
+     *
+     * @param  callable                                                                   $callback
+     * @return \Mpyw\LaravelMySqlSystemVariableManager\Replacers\BooleanReplacerInterface
+     */
+    public static function bool(callable $callback): BooleanReplacerInterface
+    {
+        return new CallbackBooleanReplacer($callback);
+    }
+
+    /**
+     * Create new float replacer for MySQL system variable.
+     *
+     * @param  callable                                                                 $callback
+     * @return \Mpyw\LaravelMySqlSystemVariableManager\Replacers\FloatReplacerInterface
+     */
+    public static function float(callable $callback): FloatReplacerInterface
+    {
+        return new CallbackFloatReplacer($callback);
+    }
+
+    /**
+     * Create new string replacer for MySQL system variable.
+     *
+     * @param  callable                                                                  $callback
+     * @return \Mpyw\LaravelMySqlSystemVariableManager\Replacers\StringReplacerInterface
+     */
+    public static function str(callable $callback): StringReplacerInterface
+    {
+        return new CallbackStringReplacer($callback);
+    }
+
+    /**
+     * Create new typed replacer for MySQL system variable.
+     *
+     * @param  string                                                      $type
+     * @param  bool|float|int|string                                       $callback
+     * @return \Mpyw\LaravelMySqlSystemVariableManager\ExpressionInterface
+     */
+    public static function as(string $type, $callback): ExpressionInterface
+    {
+        switch ($type) {
+            case ExpressionInterface::TYPE_INTEGER:
+                return static::int($callback);
+            case ExpressionInterface::TYPE_BOOLEAN:
+                return static::bool($callback);
+            case ExpressionInterface::TYPE_FLOAT:
+                return static::float($callback);
+            case ExpressionInterface::TYPE_STRING:
+                return static::str($callback);
+            default:
+                throw new InvalidArgumentException('The return type must be one of "integer", "boolean", "double" or "string".');
+        }
+    }
+}

--- a/src/Replacers/BooleanReplacerInterface.php
+++ b/src/Replacers/BooleanReplacerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Mpyw\LaravelMySqlSystemVariableManager\Replacers;
+
+use Mpyw\LaravelMySqlSystemVariableManager\ExpressionInterface;
+
+interface BooleanReplacerInterface extends ExpressionInterface
+{
+    /**
+     * Replace boolean variable value.
+     *
+     * @param  bool $value
+     * @return bool
+     */
+    public function replace(bool $value): bool;
+}

--- a/src/Replacers/CallbackBooleanReplacer.php
+++ b/src/Replacers/CallbackBooleanReplacer.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Mpyw\LaravelMySqlSystemVariableManager\Replacers;
+
+use Mpyw\LaravelMySqlSystemVariableManager\ExpressionInterface;
+use Mpyw\LaravelMySqlSystemVariableManager\ExpressionTrait;
+
+class CallbackBooleanReplacer implements BooleanReplacerInterface
+{
+    use ExpressionTrait;
+
+    /**
+     * @var callable
+     */
+    protected $callback;
+
+    /**
+     * ClosureBooleanReplacer constructor.
+     *
+     * @param callable $callback
+     */
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * Replace boolean variable value.
+     *
+     * @param  bool $value
+     * @return bool
+     */
+    public function replace(bool $value): bool
+    {
+        return ($this->callback)($value);
+    }
+
+    /**
+     * Return type.
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return ExpressionInterface::TYPE_BOOLEAN;
+    }
+}

--- a/src/Replacers/CallbackFloatReplacer.php
+++ b/src/Replacers/CallbackFloatReplacer.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Mpyw\LaravelMySqlSystemVariableManager\Replacers;
+
+use Mpyw\LaravelMySqlSystemVariableManager\ExpressionInterface;
+use Mpyw\LaravelMySqlSystemVariableManager\ExpressionTrait;
+
+class CallbackFloatReplacer implements FloatReplacerInterface
+{
+    use ExpressionTrait;
+
+    /**
+     * @var callable
+     */
+    protected $callback;
+
+    /**
+     * ClosureFloatReplacer constructor.
+     *
+     * @param callable $callback
+     */
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * Replace float variable value.
+     *
+     * @param  float $value
+     * @return float
+     */
+    public function replace(float $value): float
+    {
+        return ($this->callback)($value);
+    }
+
+    /**
+     * Return type.
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return ExpressionInterface::TYPE_FLOAT;
+    }
+}

--- a/src/Replacers/CallbackIntegerReplacer.php
+++ b/src/Replacers/CallbackIntegerReplacer.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Mpyw\LaravelMySqlSystemVariableManager\Replacers;
+
+use Mpyw\LaravelMySqlSystemVariableManager\ExpressionInterface;
+use Mpyw\LaravelMySqlSystemVariableManager\ExpressionTrait;
+
+class CallbackIntegerReplacer implements IntegerReplacerInterface
+{
+    use ExpressionTrait;
+
+    /**
+     * @var callable
+     */
+    protected $callback;
+
+    /**
+     * ClosureIntegerReplacer constructor.
+     *
+     * @param callable $callback
+     */
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * Replace integer variable value.
+     *
+     * @param  int $value
+     * @return int
+     */
+    public function replace(int $value): int
+    {
+        return ($this->callback)($value);
+    }
+
+    /**
+     * Return type.
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return ExpressionInterface::TYPE_INTEGER;
+    }
+}

--- a/src/Replacers/CallbackStringReplacer.php
+++ b/src/Replacers/CallbackStringReplacer.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Mpyw\LaravelMySqlSystemVariableManager\Replacers;
+
+use Mpyw\LaravelMySqlSystemVariableManager\ExpressionInterface;
+use Mpyw\LaravelMySqlSystemVariableManager\ExpressionTrait;
+
+class CallbackStringReplacer implements StringReplacerInterface
+{
+    use ExpressionTrait;
+
+    /**
+     * @var callable
+     */
+    protected $callback;
+
+    /**
+     * ClosureStringReplacer constructor.
+     *
+     * @param callable $callback
+     */
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * Replace string variable value.
+     *
+     * @param  string $value
+     * @return string
+     */
+    public function replace(string $value): string
+    {
+        return ($this->callback)($value);
+    }
+
+    /**
+     * Return type.
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return ExpressionInterface::TYPE_STRING;
+    }
+}

--- a/src/Replacers/FloatReplacerInterface.php
+++ b/src/Replacers/FloatReplacerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Mpyw\LaravelMySqlSystemVariableManager\Replacers;
+
+use Mpyw\LaravelMySqlSystemVariableManager\ExpressionInterface;
+
+interface FloatReplacerInterface extends ExpressionInterface
+{
+    /**
+     * Replace float variable value.
+     *
+     * @param  float $value
+     * @return float
+     */
+    public function replace(float $value): float;
+}

--- a/src/Replacers/IntegerReplacerInterface.php
+++ b/src/Replacers/IntegerReplacerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Mpyw\LaravelMySqlSystemVariableManager\Replacers;
+
+use Mpyw\LaravelMySqlSystemVariableManager\ExpressionInterface;
+
+interface IntegerReplacerInterface extends ExpressionInterface
+{
+    /**
+     * Replace integer variable value.
+     *
+     * @param  int $value
+     * @return int
+     */
+    public function replace(int $value): int;
+}

--- a/src/Replacers/StringReplacerInterface.php
+++ b/src/Replacers/StringReplacerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Mpyw\LaravelMySqlSystemVariableManager\Replacers;
+
+use Mpyw\LaravelMySqlSystemVariableManager\ExpressionInterface;
+
+interface StringReplacerInterface extends ExpressionInterface
+{
+    /**
+     * Replace string variable value.
+     *
+     * @param  string $value
+     * @return string
+     */
+    public function replace(string $value): string;
+}

--- a/src/SystemVariableAssigner.php
+++ b/src/SystemVariableAssigner.php
@@ -3,11 +3,17 @@
 namespace Mpyw\LaravelMySqlSystemVariableManager;
 
 use Closure;
+use LogicException;
+use Mpyw\LaravelMySqlSystemVariableManager\Replacers\BooleanReplacerInterface;
+use Mpyw\LaravelMySqlSystemVariableManager\Replacers\FloatReplacerInterface;
+use Mpyw\LaravelMySqlSystemVariableManager\Replacers\IntegerReplacerInterface;
+use Mpyw\LaravelMySqlSystemVariableManager\Replacers\StringReplacerInterface;
 use Mpyw\LaravelMySqlSystemVariableManager\Value as BindingValue;
 use Mpyw\LaravelPdoEmulationControl\EmulationController;
 use Mpyw\Unclosure\Value;
 use PDO;
 use Mpyw\LaravelMySqlSystemVariableManager\SystemVariableGrammar as Grammar;
+use PDOStatement;
 
 class SystemVariableAssigner
 {
@@ -62,10 +68,10 @@ class SystemVariableAssigner
     }
 
     /**
-     * @param  PDO    $pdo
+     * @param  \PDO   $pdo
      * @param  string $query
      * @param  array  $values
-     * @return PDO
+     * @return \PDO
      */
     protected static function withEmulatedStatementFor(PDO $pdo, string $query, array $values): PDO
     {
@@ -78,20 +84,67 @@ class SystemVariableAssigner
     }
 
     /**
-     * @param  PDO    $pdo
+     * @param  \PDO   $pdo
      * @param  string $query
      * @param  array  $values
-     * @return PDO
+     * @return \PDO
      */
     protected static function withStatementFor(PDO $pdo, string $query, array $values): PDO
     {
+        $expressions = array_map([BindingValue::class, 'wrap'], $values);
+        $original = static::selectOriginalVariablesForReplacer($pdo, $expressions);
         $statement = $pdo->prepare($query);
-        foreach (array_values($values) as $i => $value) {
-            $value = BindingValue::wrap($value);
-            $statement->bindValue($i + 1, $value->getValue(), $value->getParamType());
+
+        $i = 0;
+        foreach ($expressions as $key => $expression) {
+            static::bindValue($statement, ++$i, $expression, $original[$key] ?? null);
         }
         $statement->execute();
 
         return $pdo;
+    }
+
+    /**
+     * @param  \PDO                                                          $pdo
+     * @param  \Mpyw\LaravelMySqlSystemVariableManager\ExpressionInterface[] $expressions
+     * @return \Mpyw\LaravelMySqlSystemVariableManager\ValueInterface[]
+     */
+    protected static function selectOriginalVariablesForReplacer(PDO $pdo, array $expressions): array
+    {
+        $replacers = array_filter($expressions, function ($value) {
+            return $value instanceof IntegerReplacerInterface
+                || $value instanceof BooleanReplacerInterface
+                || $value instanceof FloatReplacerInterface
+                || $value instanceof StringReplacerInterface;
+        });
+
+        return SystemVariableSelector::selectOriginalVariables($pdo, $replacers);
+    }
+
+    /**
+     * @param \PDOStatement                                               $statement
+     * @param int                                                         $parameter
+     * @param \Mpyw\LaravelMySqlSystemVariableManager\ExpressionInterface $expression
+     * @param null|\Mpyw\LaravelMySqlSystemVariableManager\ValueInterface $original
+     */
+    protected static function bindValue(PDOStatement $statement, int $parameter, ExpressionInterface $expression, ?ValueInterface $original = null): void
+    {
+        if ($expression instanceof ValueInterface) {
+            $statement->bindValue($parameter, $expression->getValue(), $expression->getParamType());
+            return;
+        }
+
+        if (($expression instanceof IntegerReplacerInterface
+            || $expression instanceof BooleanReplacerInterface
+            || $expression instanceof FloatReplacerInterface
+            || $expression instanceof StringReplacerInterface
+            ) && $original) {
+            $statement->bindValue($parameter, $expression->replace($original->getValue()), $expression->getParamType());
+            return;
+        }
+
+        // @codeCoverageIgnoreStart
+        throw new LogicException('Unreachable code.');
+        // @codeCoverageIgnoreEnd
     }
 }

--- a/src/SystemVariableGrammar.php
+++ b/src/SystemVariableGrammar.php
@@ -5,6 +5,28 @@ namespace Mpyw\LaravelMySqlSystemVariableManager;
 class SystemVariableGrammar
 {
     /**
+     * @param  string[] $variables
+     * @return string
+     */
+    public static function selectStatement(array $variables): string
+    {
+        return 'select ' . implode(', ', static::variableExpressions($variables));
+    }
+
+    /**
+     * @param  string[] $variables
+     * @return string[]
+     */
+    public static function variableExpressions(array $variables): array
+    {
+        $expressions = [];
+        foreach ($variables as $variable) {
+            $expressions[] = sprintf('@@%1$s as %1$s', static::escapeIdentifier($variable));
+        }
+        return $expressions;
+    }
+
+    /**
      * @param  array  $values
      * @return string
      */

--- a/src/SystemVariableSelector.php
+++ b/src/SystemVariableSelector.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Mpyw\LaravelMySqlSystemVariableManager;
+
+use Mpyw\LaravelMySqlSystemVariableManager\Value as BindingValue;
+use PDO;
+
+class SystemVariableSelector
+{
+    /**
+     * Select current MySQL system variable values.
+     *
+     * @param  \PDO                                                     $pdo
+     * @param  array                                                    $newValues
+     * @return \Mpyw\LaravelMySqlSystemVariableManager\ValueInterface[]
+     */
+    public static function selectOriginalVariables(PDO $pdo, array $newValues): array
+    {
+        if (!$newValues) {
+            return [];
+        }
+
+        $original = $pdo
+            ->query(SystemVariableGrammar::selectStatement(array_keys($newValues)))
+            ->fetch(PDO::FETCH_ASSOC);
+
+        foreach ($original as $key => $value) {
+            $original[$key] = BindingValue::as(BindingValue::wrap($newValues[$key])->getType(), $value);
+        }
+
+        return $original;
+    }
+}

--- a/src/SystemVariableTemporaryAssigner.php
+++ b/src/SystemVariableTemporaryAssigner.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Mpyw\LaravelMySqlSystemVariableManager;
+
+use Mpyw\Unclosure\Value;
+use PDO;
+
+class SystemVariableTemporaryAssigner
+{
+    /**
+     * @var \Closure[]|\PDO[]
+     */
+    protected $pdos;
+
+    /**
+     * SystemVariableAssigner constructor.
+     *
+     * @param null|\Closure|\PDO &...$pdos
+     */
+    public function __construct(&...$pdos)
+    {
+        $this->pdos = array_filter($pdos);
+    }
+
+    /**
+     * Temporarily set MySQL system variables for PDO.
+     *
+     * @param  array    $using
+     * @param  callable $callback
+     * @param  array    $args
+     * @return $this
+     */
+    public function using(array $using, callable $callback, ...$args)
+    {
+        return Value::withEffectForEach($this->pdos, function (PDO $pdo) use ($using) {
+            $original = SystemVariableSelector::selectOriginalVariables($pdo, $using);
+            (new SystemVariableAssigner($pdo))->assign($using);
+
+            return function (PDO $pdo) use ($original) {
+                (new SystemVariableAssigner($pdo))->assign($original);
+            };
+        }, $callback, ...$args);
+    }
+}

--- a/src/ValueInterface.php
+++ b/src/ValueInterface.php
@@ -2,38 +2,12 @@
 
 namespace Mpyw\LaravelMySqlSystemVariableManager;
 
-interface ValueInterface
+interface ValueInterface extends ExpressionInterface
 {
-    public const TYPE_INT = 'integer';
-    public const TYPE_BOOL = 'boolean';
-    public const TYPE_FLOAT = 'double';
-    public const TYPE_STR = 'string';
-
     /**
      * Return original value.
      *
      * @return bool|float|int|string
      */
     public function getValue();
-
-    /**
-     * Return type.
-     *
-     * @return string
-     */
-    public function getType(): string;
-
-    /**
-     * Return PDO::PARAM_* type.
-     *
-     * @return int
-     */
-    public function getParamType(): int;
-
-    /**
-     * Return placeholder for prepared statement.
-     *
-     * @return string
-     */
-    public function getPlaceholder(): string;
 }

--- a/tests/BasicVariableAssignmentTest.php
+++ b/tests/BasicVariableAssignmentTest.php
@@ -4,6 +4,7 @@ namespace Mpyw\LaravelMySqlSystemVariableManager\Tests;
 
 use InvalidArgumentException;
 use Mpyw\LaravelMySqlSystemVariableManager\MySqlConnection;
+use Mpyw\LaravelMySqlSystemVariableManager\Replacer;
 use Mpyw\LaravelMySqlSystemVariableManager\Value;
 
 class BasicVariableAssignmentTest extends TestCase
@@ -17,12 +18,32 @@ class BasicVariableAssignmentTest extends TestCase
      * @param mixed  $expectedChanged
      * @dataProvider provideBasicVariables
      */
-    public function testBasicVariables(string $variableName, bool $emulated, $expectedOriginal, $newValue, $expectedChanged): void
+    public function testAssignments(string $variableName, bool $emulated, $expectedOriginal, $newValue, $expectedChanged): void
     {
         $this->{$emulated ? 'onEmulatedConnection' : 'onNativeConnection'}(function (MySqlConnection $db) use ($variableName, $expectedOriginal, $newValue, $expectedChanged) {
             $this->assertSame($expectedOriginal, $db->selectOne("select @@{$variableName} as value")->value);
             $db->setSystemVariable($variableName, $newValue);
             $this->assertSame($expectedChanged, $db->selectOne("select @@{$variableName} as value")->value);
+        });
+    }
+
+    /**
+     * @test
+     * @param string $variableName
+     * @param bool   $emulated
+     * @param mixed  $expectedOriginal
+     * @param mixed  $newValue
+     * @param mixed  $expectedChanged
+     * @dataProvider provideBasicVariables
+     */
+    public function testTemporaryAssignments(string $variableName, bool $emulated, $expectedOriginal, $newValue, $expectedChanged): void
+    {
+        $this->{$emulated ? 'onEmulatedConnection' : 'onNativeConnection'}(function (MySqlConnection $db) use ($variableName, $expectedOriginal, $newValue, $expectedChanged) {
+            $this->assertSame($expectedOriginal, $db->selectOne("select @@{$variableName} as value")->value);
+            $db->usingSystemVariable($variableName, $newValue, function () use ($expectedChanged, $db, $variableName) {
+                $this->assertSame($expectedChanged, $db->selectOne("select @@{$variableName} as value")->value);
+            });
+            $this->assertSame($expectedOriginal, $db->selectOne("select @@{$variableName} as value")->value);
         });
     }
 
@@ -48,13 +69,29 @@ class BasicVariableAssignmentTest extends TestCase
             'assigning wrapped boolean (emulated)' => ['foreign_key_checks', true, '1', Value::bool(false), '0'],
             'assigning wrapped string (native)' => ['tx_isolation', false, 'REPEATABLE-READ', Value::str('read-committed'), 'READ-COMMITTED'],
             'assigning wrapped string (emulated)' => ['tx_isolation', true, 'REPEATABLE-READ', Value::str('read-committed'), 'READ-COMMITTED'],
+            'replacing explicit float (native)' => ['long_query_time', false, 10.0, Replacer::float(function ($v) { return $v + 5.0; }), 15.0],
+            'replacing explicit float (emulated)' => ['long_query_time', true, '10.000000', Replacer::float(function ($v) { return $v + 5.0; }), '15.000000'],
+            'replacing explicit integer (native)' => ['long_query_time', false, 10.0, Replacer::int(function ($v) { return $v + 5; }), 15.0],
+            'replacing explicit integer (emulated)' => ['long_query_time', true, '10.000000', Replacer::int(function ($v) { return $v + 5; }), '15.000000'],
+            'replacing explicit boolean (native)' => ['foreign_key_checks', false, 1, Replacer::bool(function ($v) { return !$v; }), 0],
+            'replacing explicit boolean (emulated)' => ['foreign_key_checks', true, '1', Replacer::bool(function ($v) { return !$v; }), '0'],
+            'replacing explicit string (native)' => ['tx_isolation', false, 'REPEATABLE-READ', Replacer::str(function ($v) { return str_ireplace('repeatable-read', 'read-committed', $v); }), 'READ-COMMITTED'],
+            'replacing explicit string (emulated)' => ['tx_isolation', true, 'REPEATABLE-READ', Replacer::str(function ($v) { return str_ireplace('repeatable-read', 'read-committed', $v); }), 'READ-COMMITTED'],
+            'replacing implicit float (native)' => ['long_query_time', false, 10.0, function ($v): float { return $v + 5.0; }, 15.0],
+            'replacing implicit float (emulated)' => ['long_query_time', true, '10.000000', function ($v): float { return $v + 5.0; }, '15.000000'],
+            'replacing implicit integer (native)' => ['long_query_time', false, 10.0, function ($v): int { return $v + 5; }, 15.0],
+            'replacing implicit integer (emulated)' => ['long_query_time', true, '10.000000', function ($v): int { return $v + 5; }, '15.000000'],
+            'replacing implicit boolean (native)' => ['foreign_key_checks', false, 1, function ($v): bool { return !$v; }, 0],
+            'replacing implicit boolean (emulated)' => ['foreign_key_checks', true, '1', function ($v): bool { return !$v; }, '0'],
+            'replacing implicit string (native)' => ['tx_isolation', false, 'REPEATABLE-READ', function ($v): string { return str_ireplace('repeatable-read', 'read-committed', $v); }, 'READ-COMMITTED'],
+            'replacing implicit string (emulated)' => ['tx_isolation', true, 'REPEATABLE-READ', function ($v): string { return str_ireplace('repeatable-read', 'read-committed', $v); }, 'READ-COMMITTED'],
         ];
     }
 
     public function testAssigningNullThrowsExceptionOnNative(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The value must be a scalar or Mpyw\LaravelMySqlSystemVariableManager\ValueInterface instance.');
+        $this->expectExceptionMessage('The value must be a scalar, return-type-explicit closure or Mpyw\LaravelMySqlSystemVariableManager\ExpressionInterface instance.');
 
         $this->onNativeConnection(function (MySqlConnection $db) {
             $db->setSystemVariable('foreign_key_checks', null);
@@ -65,7 +102,7 @@ class BasicVariableAssignmentTest extends TestCase
     public function testAssigningNullThrowsExceptionOnEmulation(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The value must be a scalar or Mpyw\LaravelMySqlSystemVariableManager\ValueInterface instance.');
+        $this->expectExceptionMessage('The value must be a scalar, return-type-explicit closure or Mpyw\LaravelMySqlSystemVariableManager\ExpressionInterface instance.');
 
         $this->onEmulatedConnection(function (MySqlConnection $db) {
             $db->setSystemVariable('foreign_key_checks', null);
@@ -76,7 +113,7 @@ class BasicVariableAssignmentTest extends TestCase
     public function testAssigningNullThrowsOnUnresolvedNativeConnection(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The value must be a scalar or Mpyw\LaravelMySqlSystemVariableManager\ValueInterface instance.');
+        $this->expectExceptionMessage('The value must be a scalar, return-type-explicit closure or Mpyw\LaravelMySqlSystemVariableManager\ExpressionInterface instance.');
 
         $this->onNativeConnection(function (MySqlConnection $db) {
             $db->setSystemVariable('foreign_key_checks', null);
@@ -86,7 +123,7 @@ class BasicVariableAssignmentTest extends TestCase
     public function testAssigningNullThrowsOnUnresolvedEmulatedConnection(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The value must be a scalar or Mpyw\LaravelMySqlSystemVariableManager\ValueInterface instance.');
+        $this->expectExceptionMessage('The value must be a scalar, return-type-explicit closure or Mpyw\LaravelMySqlSystemVariableManager\ExpressionInterface instance.');
 
         $this->onEmulatedConnection(function (MySqlConnection $db) {
             $db->setSystemVariable('foreign_key_checks', null);


### PR DESCRIPTION
# New Feature

## Temporary Assignments

- `DB::usingSystemVariable()`
- `DB::usingSystemVariables()`

## Replacing Variables

Pass **return-type-explicit** `Closure` as value.

```php
DB::usingSystemVariable('sql_mode', function (string $mode): string {
    return str_replace('ONLY_FULL_GROUP_BY', '', $mode);
}, $callback, ...$args);
```